### PR TITLE
Single sync callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This decorator on the other hand, hold a transient cache for the duration of the
 |`clear` |![#f03c15](https://placehold.it/15/f03c15/000000?text=+) Not visible|![#c5f015](https://placehold.it/15/c5f015/000000?text=+) Visible|
 
 ## Will this make my cache transactional?
-No, it will not. This decorator will just prevent the underlying cache to be populated with data before the transaction is committed. Also, the cache isolation can be considered `READ COMMITTED`, i.e. if another transaction updates the cache (and commits) it will be instantly visible, with the exception of if the `cacheCacheResult` is enabled and the value has already been read.
+No, it will not. This decorator will just prevent the underlying cache to be populated with data before the transaction is committed. Also, the cache isolation can be considered `READ COMMITTED`, i.e. if another transaction updates the cache (and commits) it will be instantly visible, exception if the `cacheCacheResult` is enabled, and the value has already been read.
 
 ## References
 * https://github.com/spring-projects/spring-framework/issues/17353

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
     <groupId>com.ethlo.cache</groupId>
     <artifactId>spring-tx-cache-decorator</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/src/main/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecorator.java
+++ b/src/main/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecorator.java
@@ -38,12 +38,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class EnhancedTransactionAwareCacheDecorator implements Cache
 {
     private static final Logger logger = LoggerFactory.getLogger(EnhancedTransactionAwareCacheDecorator.class);
-
+    private static final ThreadLocal<TransactionCacheState> transientData = ThreadLocal.withInitial(TransactionCacheState::new);
     private final Cache cache;
     private final boolean errorOnUnsafe;
-
-    // Important: NOT static as we need one for each cache instance
-    private final ThreadLocal<TransientCacheData> transientData = ThreadLocal.withInitial(TransientCacheData::new);
     private final boolean cacheCacheResult;
 
     public EnhancedTransactionAwareCacheDecorator(final Cache cache)
@@ -52,8 +49,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
     }
 
     /**
-     *
-     * @param cache The cache to delegate to
+     * @param cache            The cache to delegate to
      * @param cacheCacheResult Whether to cache the result from the delegate cache result until the end of the transaction
      */
     public EnhancedTransactionAwareCacheDecorator(final Cache cache, final boolean cacheCacheResult)
@@ -68,14 +64,21 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
         this.cacheCacheResult = cacheCacheResult;
     }
 
+    public static void reset()
+    {
+        transientData.remove();
+    }
+
     @Override
-    public @NonNull String getName()
+    public @NonNull
+    String getName()
     {
         return cache.getName();
     }
 
     @Override
-    public @NonNull Object getNativeCache()
+    public @NonNull
+    Object getNativeCache()
     {
         return cache.getNativeCache();
     }
@@ -84,7 +87,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
     @Nullable
     public ValueWrapper get(@NonNull final Object key)
     {
-        final TransientCacheData tcd = transientData.get();
+        final TransientCacheData tcd = tcd();
         final ValueWrapper res = tcd.getTransientCache().get(key);
         if (res != null && isNull(res))
         {
@@ -97,9 +100,8 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
         }
         else if (!tcd.isCacheCleared())
         {
-            logger.debug("Fetching {} from cache", key);
+            logger.debug("Fetching {} from underlying cache {}", key, cache.getName());
             final ValueWrapper fromRealCache = cache.get(key);
-
             final ValueWrapper result = Optional.ofNullable(fromRealCache).map(ValueWrapper::get).map(ReadOnlyValueWrapper::new).filter(v -> !isNull(v)).orElse(new ReadOnlyValueWrapper(null));
 
             if (cacheCacheResult)
@@ -121,6 +123,12 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
         return null;
     }
 
+    private TransientCacheData tcd()
+    {
+        logger.trace("Getting transient cache for {}", cache.getName());
+        return transientData.get().get(cache.getName());
+    }
+
     @Override
     @Nullable
     public <T> T get(final @NonNull Object key, final Class<T> type)
@@ -139,7 +147,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
         }
 
         final T storedData = (T) new LoadFunction(valueLoader).apply(key);
-        final TransientCacheData tcd = transientData.get();
+        final TransientCacheData tcd = tcd();
 
         try
         {
@@ -154,35 +162,33 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
 
     private void cacheSync()
     {
-        final TransientCacheData tcd = transientData.get();
-        if (tcd.isSyncSetup())
-        {
-            logger.debug("Cache sync transaction already set up. Skipping");
-            return;
-        }
-
         if (TransactionSynchronizationManager.isSynchronizationActive())
         {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter()
+            if (!transientData.get().isSyncSetup())
             {
-                @Override
-                public void afterCommit()
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter()
                 {
-                    copyTransient();
-                }
+                    @Override
+                    public void afterCommit()
+                    {
+                        logger.debug("Transaction commit. Copying to underlying cache");
+                        copyTransient();
+                    }
 
-                @Override
-                public void afterCompletion(final int status)
-                {
-                    transientData.remove();
-                    logger.debug("Transaction completed. Cleared transient data");
-                }
-            });
-            tcd.syncSetup();
-            logger.debug("Cache sync transaction callback added");
+                    @Override
+                    public void afterCompletion(final int status)
+                    {
+                        transientData.remove();
+                        logger.debug("Transaction completed. Cleared transient data for cache {}", cache.getName());
+                    }
+                });
+                transientData.get().syncSetup();
+                logger.debug("Cache sync transaction callback added");
+            }
         }
         else
         {
+            logger.debug("Sync outside of active transaction for cache {}", cache.getName());
             copyTransient();
         }
     }
@@ -194,36 +200,38 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
 
     private void copyTransient()
     {
-        final TransientCacheData tcd = transientData.get();
-
-        if (tcd.isCacheCleared())
+        transientData.get().transientCaches().forEach((name, tcd) ->
         {
-            cache.clear();
-        }
+            if (tcd.isCacheCleared())
+            {
+                cache.clear();
+            }
 
-        for (Map.Entry<Object, ValueWrapper> entry : tcd.getTransientCache().entrySet())
-        {
-            final Object key = entry.getKey();
-            final ValueWrapper valueWrapper = entry.getValue();
-            final Object value = valueWrapper.get();
-            if (value == NullValue.INSTANCE)
+            for (Map.Entry<Object, ValueWrapper> entry : tcd.getTransientCache().entrySet())
             {
-                logger.debug("Evicting {} from cache {}", key, getName());
-                cache.evict(key);
+                final Object key = entry.getKey();
+                final ValueWrapper valueWrapper = entry.getValue();
+                final Object value = valueWrapper.get();
+                if (value == NullValue.INSTANCE)
+                {
+                    logger.debug("Evicting {} from underlying cache {}", key, getName());
+                    cache.evict(key);
+                }
+                else if (!(valueWrapper instanceof ReadOnlyValueWrapper))
+                {
+                    logger.debug("Setting {}={} in underlying cache {}", key, value, getName());
+                    cache.put(key, value);
+                }
             }
-            else if (!(valueWrapper instanceof ReadOnlyValueWrapper))
-            {
-                logger.debug("Setting {}={} in cache {}", key, value, getName());
-                cache.put(key, value);
-            }
-        }
-        tcd.getTransientCache().clear();
+
+            tcd.getTransientCache().clear();
+        });
     }
 
     @Override
     public void put(final @NonNull Object key, final Object value)
     {
-        final TransientCacheData tcd = transientData.get();
+        final TransientCacheData tcd = tcd();
         try
         {
             tcd.getTransientCache().put(key, new SimpleValueWrapper(value));
@@ -247,7 +255,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
     @Override
     public void evict(final @NonNull Object key)
     {
-        final TransientCacheData tcd = transientData.get();
+        final TransientCacheData tcd = tcd();
         try
         {
             tcd.getTransientCache().put(key, new SimpleValueWrapper(NullValue.INSTANCE));
@@ -260,7 +268,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
     @Override
     public void clear()
     {
-        final TransientCacheData tcd = transientData.get();
+        final TransientCacheData tcd = tcd();
         try
         {
             tcd.cleared();

--- a/src/main/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecorator.java
+++ b/src/main/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecorator.java
@@ -100,7 +100,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
         }
         else if (!tcd.isCacheCleared())
         {
-            logger.debug("Fetching {} from underlying cache {}", key, cache.getName());
+            logger.debug("Fetching {} from delegate cache {}", key, cache.getName());
             final ValueWrapper fromRealCache = cache.get(key);
             final ValueWrapper result = Optional.ofNullable(fromRealCache).map(ValueWrapper::get).map(ReadOnlyValueWrapper::new).filter(v -> !isNull(v)).orElse(new ReadOnlyValueWrapper(null));
 
@@ -108,7 +108,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
             {
                 try
                 {
-                    // Avoid the underlying cache being utilized again for this transaction
+                    // Avoid the delegate cache being utilized again for this transaction
                     tcd.getTransientCache().put(key, result);
                 } finally
                 {
@@ -171,7 +171,7 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
                     @Override
                     public void afterCommit()
                     {
-                        logger.debug("Transaction commit. Copying to underlying cache");
+                        logger.debug("Transaction commit. Copying to delegate cache");
                         copyTransient();
                     }
 
@@ -214,12 +214,12 @@ public class EnhancedTransactionAwareCacheDecorator implements Cache
                 final Object value = valueWrapper.get();
                 if (value == NullValue.INSTANCE)
                 {
-                    logger.debug("Evicting {} from underlying cache {}", key, getName());
+                    logger.debug("Evicting {} from delegate cache {}", key, getName());
                     cache.evict(key);
                 }
                 else if (!(valueWrapper instanceof ReadOnlyValueWrapper))
                 {
-                    logger.debug("Setting {}={} in underlying cache {}", key, value, getName());
+                    logger.debug("Setting {}={} in delegate cache {}", key, value, getName());
                     cache.put(key, value);
                 }
             }

--- a/src/main/java/com/ethlo/cache/spring/ReadOnlyValueWrapper.java
+++ b/src/main/java/com/ethlo/cache/spring/ReadOnlyValueWrapper.java
@@ -23,7 +23,7 @@ package com.ethlo.cache.spring;
 import org.springframework.cache.support.SimpleValueWrapper;
 
 /**
- * Marker for not writing the value back to the underlying cache (as this value came from the cache with read operation)
+ * Marker for not writing the value back to the delegate cache (as this value came from the cache with read operation)
  */
 public class ReadOnlyValueWrapper extends SimpleValueWrapper
 {

--- a/src/main/java/com/ethlo/cache/spring/ReadOnlyValueWrapper.java
+++ b/src/main/java/com/ethlo/cache/spring/ReadOnlyValueWrapper.java
@@ -31,4 +31,10 @@ public class ReadOnlyValueWrapper extends SimpleValueWrapper
     {
         super(value);
     }
+
+    @Override
+    public String toString()
+    {
+        return "ReadOnlyValueWrapper{" + get() + "}";
+    }
 }

--- a/src/main/java/com/ethlo/cache/spring/TransactionCacheState.java
+++ b/src/main/java/com/ethlo/cache/spring/TransactionCacheState.java
@@ -4,14 +4,14 @@ package com.ethlo.cache.spring;
  * #%L
  * spring-tx-cache-decorator
  * %%
- * Copyright (C) 2018 - 2019 Morten Haraldsen (ethlo)
+ * Copyright (C) 2018 - 2020 Morten Haraldsen (ethlo)
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,29 +20,32 @@ package com.ethlo.cache.spring;
  * #L%
  */
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.cache.Cache;
-
-public class TransientCacheData
+public class TransactionCacheState
 {
-    private final Map<Object, Cache.ValueWrapper> transientCache = new ConcurrentHashMap<>();
+    private final Map<String, TransientCacheData> transientCaches = new HashMap<>();
 
-    private boolean isCleared = false;
+    private boolean hasSyncSetup = false;
 
-    public boolean isCacheCleared()
+    public boolean isSyncSetup()
     {
-        return isCleared;
+        return hasSyncSetup;
     }
 
-    public void cleared()
+    public void syncSetup()
     {
-        isCleared = true;
+        this.hasSyncSetup = true;
     }
 
-    public Map<Object, Cache.ValueWrapper> getTransientCache()
+    public TransientCacheData get(final String cacheName)
     {
-        return this.transientCache;
+        return transientCaches.computeIfAbsent(cacheName, (key) -> new TransientCacheData());
+    }
+
+    public Map<String, TransientCacheData> transientCaches()
+    {
+        return transientCaches;
     }
 }

--- a/src/main/java/com/ethlo/cache/spring/TransactionCacheState.java
+++ b/src/main/java/com/ethlo/cache/spring/TransactionCacheState.java
@@ -9,9 +9,9 @@ package com.ethlo.cache.spring;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecoratorTest.java
+++ b/src/test/java/com/ethlo/cache/spring/EnhancedTransactionAwareCacheDecoratorTest.java
@@ -37,6 +37,7 @@ public class EnhancedTransactionAwareCacheDecoratorTest extends AbstractTransact
     @Before
     public void setup()
     {
+        EnhancedTransactionAwareCacheDecorator.reset();
         realCache = new ConcurrentHashMap<>();
         decorator = new EnhancedTransactionAwareCacheDecorator(new ConcurrentMapCache("my-cache", realCache, true));
     }


### PR DESCRIPTION
Use single sync callback (not one per cache). Added reset() method that can be called at transaction start 